### PR TITLE
Allow return status 204 for deletions

### DIFF
--- a/zenhub/core.py
+++ b/zenhub/core.py
@@ -54,7 +54,7 @@ class Zenhub(object):
         """Parse response and convert to json if possible."""
         contents = {}
         status_code = response.status_code
-        if status_code == 200:
+        if status_code == 200 or status_code == 204:
             if response.text:
                 try:
                     contents = response.json()

--- a/zenhub/core.py
+++ b/zenhub/core.py
@@ -95,17 +95,17 @@ class Zenhub(object):
 
     def _put(self, url, body):
         """Send PUT request with given url and data."""
-        response = self._session.put(url=self._make_url(url), data=body)
+        response = self._session.put(url=self._make_url(url), json=body)
         return self._parse_response_contents(response)
 
     def _delete(self, url, body={}):
         """Send DELETE request with given url and data."""
-        response = self._session.delete(url=self._make_url(url), data=body)
+        response = self._session.delete(url=self._make_url(url), json=body)
         return self._parse_response_contents(response)
 
     def _patch(self, url, body):
         """Send PATCH request with given url and data."""
-        response = self._session.patch(url=self._make_url(url), data=body)
+        response = self._session.patch(url=self._make_url(url), json=body)
         return self._parse_response_contents(response)
 
     # --- Issues


### PR DESCRIPTION
resolves #8 

Example - Delete dependency:

```
z.remove_dependency(repoID, 122, repoID, 123)
```
The dependency was deleted however the following error was raised due to the status code not being one of the ones listed as accepted:

```
Traceback (most recent call last):
  File "/Users/sianob/workspaces/ws-1/GitHub/src/UpdateIssues.py", line 7, in <module>
    z.remove_dependency(repoID, 122, repoID, 123)
  File "/usr/local/lib/python3.9/site-packages/zenhub/core.py", line 337, in remove_dependency
    return self._delete(url, body)
  File "/usr/local/lib/python3.9/site-packages/zenhub/core.py", line 108, in _delete
    return self._parse_response_contents(response)
  File "/usr/local/lib/python3.9/site-packages/zenhub/core.py", line 72, in _parse_response_contents
    raise ZenhubError("Unknown error!")
zenhub.core.ZenhubError: Unknown error!
```
