### PR TITLE
Submit body as json for _put, _delete, _patch

### DIFF
--- a/zenhub/core.py
+++ b/zenhub/core.py
@@ -95,17 +95,17 @@ class Zenhub(object):
 
     def _put(self, url, body):
         """Send PUT request with given url and data."""
-        response = self._session.put(url=self._make_url(url), data=body)
+        response = self._session.put(url=self._make_url(url), json=body)
         return self._parse_response_contents(response)
 
     def _delete(self, url, body={}):
         """Send DELETE request with given url and data."""
-        response = self._session.delete(url=self._make_url(url), data=body)
+        response = self._session.delete(url=self._make_url(url), json=body)
         return self._parse_response_contents(response)
 
     def _patch(self, url, body):
         """Send PATCH request with given url and data."""
-        response = self._session.patch(url=self._make_url(url), data=body)
+        response = self._session.patch(url=self._make_url(url), json=body)
         return self._parse_response_contents(response)
 
     # --- Issues


### PR DESCRIPTION
When trying to assign points to an issue I discovered that the _put method doesn't work because it doesn't do the json serialization correctly, and you get a 400 from the zenhub service. This changes that for the other methods with body parameters to act like _post.